### PR TITLE
Fixes download from file:// on linux systems

### DIFF
--- a/maven-external-dependency-plugin/src/main/java/com/savage7/maven/plugin/dependency/ResolveExternalDependencyMojo.java
+++ b/maven-external-dependency-plugin/src/main/java/com/savage7/maven/plugin/dependency/ResolveExternalDependencyMojo.java
@@ -183,7 +183,10 @@ public class ResolveExternalDependencyMojo extends
                             //FileUtils.copyURLToFile(downloadUrl, tempDownloadFile);
 
                             //vharseko@openam.org.ru
-                            String endPointUrl = downloadUrl.getProtocol() + "://"+ downloadUrl.getAuthority();
+                            String endPointUrl = downloadUrl.getAuthority() == null 
+                                    || downloadUrl.getAuthority().isEmpty() 
+                                    ? downloadUrl.getProtocol()
+                                    : downloadUrl.getProtocol() + "://"+ downloadUrl.getAuthority();
                             Repository repository = new Repository("additonal-configs", endPointUrl);
                             Wagon wagon = wagonManager.getWagon(downloadUrl.getProtocol());
                             if (getLog().isDebugEnabled())


### PR DESCRIPTION
Hi, 
using as downloadUrl `file://${project.basedir}/path` on a linux system there was an error caused by the null value of the url authority. This error resulted in `file:// - Session: Connection refused`.

With this change, if the url authority is null, we have `file - Session: Opened`.